### PR TITLE
Bug fix: Websockets not handling threads properly

### DIFF
--- a/daebus/modules/websocket.py
+++ b/daebus/modules/websocket.py
@@ -159,9 +159,12 @@ class DaebusWebSocket:
             self.logger.info(f"WebSocket server listening on port {self.port}")
             
             # Keep the server running until the daemon is shut down
-            try:
+            async def keep_running():
                 while running() and self.is_running:
-                    loop.run_until_complete(asyncio.sleep(1))
+                    await asyncio.sleep(1)
+            
+            try:
+                loop.run_until_complete(keep_running())
             except Exception as e:
                 self.logger.error(f"Error in WebSocket server: {e}")
             finally:


### PR DESCRIPTION
This pull request refactors the `run_websocket_server` method in `daebus/modules/websocket.py` to improve its use of asynchronous programming. The most important change involves replacing a blocking loop with an asynchronous coroutine to ensure better compatibility with asyncio.

### Improvements to asynchronous handling:

* Refactored the loop in `run_websocket_server` to use an `async def keep_running` coroutine, replacing the blocking `loop.run_until_complete(asyncio.sleep(1))` with the non-blocking `await asyncio.sleep(1)`. This enhances the method's compatibility with asyncio's event loop and avoids potential blocking issues. (`[daebus/modules/websocket.pyL162-R167](diffhunk://#diff-3e7e65f39d5182b3b924ed32941ae67af9238c52accc34a5976a42d270abd737L162-R167)`)